### PR TITLE
Update location of pip (again)

### DIFF
--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -176,7 +176,7 @@ function  qs_bootstrap_pip() {
             curl --silent \
              --show-error \
             --retry 5 \
-            https://bootstrap.pypa.io/2.7/get-pip.py | sudo $PYTHON_EXECUTEABLE
+            https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo $PYTHON_EXECUTEABLE
         fi
     else
         echo $PYTHON_EXECUTEABLE
@@ -292,7 +292,7 @@ function qs_aws-cfn-bootstrap() {
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "20.04" ]; then
         sudo apt-get update -y
         apt-get install python2.7 -y
-        curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py
+        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
         sudo python2.7 get-pip.py
         sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "rhel" ]; then


### PR DESCRIPTION
The old URL returns a script that prints an error message:
```
Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py

Sorry if this change causes any inconvenience for you!

We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.

There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.

Thanks for understanding!

- Pradyun, on behalf of the volunteers who maintain pip.
```